### PR TITLE
Fix claimed amount

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -55,6 +55,7 @@ export default function IndexPage() {
       </Grid>
       <Card className="mt-6">
         <Title>Weekly Revenue Data</Title>
+        <Text>** From week 1 to week 20 revenue backlog was used.</Text>
         <RevShareTable revArray={revArray} ticker={ticker}/>
       </Card>
      

--- a/app/revData.ts
+++ b/app/revData.ts
@@ -431,7 +431,7 @@ export const revArray = [
       totalRewardedPoints: 372151,
       freeLoansBanxPoints: 0,
       claimedShare: 0.7697340117481591,
-      claimedSol: 133.16398403243153,
+      claimedSol: 173,
       unclaimedShare: 0.23026598825184083,
       ratioPerPoint: 0.0003578224538760652
   },
@@ -445,7 +445,7 @@ export const revArray = [
     totalRewardedPoints: 337549,
     freeLoansBanxPoints: 0,
     claimedShare: 0.6981653842971788,
-    claimedSol: 76.10002688839249,
+    claimedSol: 109,
     unclaimedShare: 0.3018346157028212,
     ratioPerPoint: 0.00022544882932075785
   }


### PR DESCRIPTION
You're setting the claimed amount to the actual claimed amount when it should be to the Total Revenue distributed as you set it before.

on data structure claimedSol = Total Revenue distributed
Then with the percents of claimed/unclaimed those amount are calculated.

Also add notice on table that rev backlog was used on first 20 weeks